### PR TITLE
Feature: support for KVM on Linux

### DIFF
--- a/molecule_qemu/playbooks/create.yml
+++ b/molecule_qemu/playbooks/create.yml
@@ -24,6 +24,14 @@
     https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
 
   tasks:
+    - name: Gather only necessary facts
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - architecture
+          - distribution
+
     ### configuration #########################################################
 
     - name: Register VMs data
@@ -103,6 +111,7 @@
     ### capabilities ##########################################################
 
     - name: Read kern.hv_support
+      when: ansible_system == 'Darwin'
       ansible.builtin.command: sysctl kern.hv_support
       register: hv_support
       changed_when: false
@@ -111,7 +120,19 @@
     - name: Set hvf support
       ansible.builtin.set_fact:
         qemu_cap_hvf: "{{ hv_support.stdout | trim == 'kern.hv_support: 1' }}"
-      when: hv_support is defined
+      when: hv_support is defined and ansible_system == 'Darwin'
+
+    - name: Check kvm support
+      when: ansible_system == 'Linux'
+      ansible.builtin.shell: (grep -q vmx /proc/cpuinfo || grep -q svm /proc/cpuinfo) && lsmod | grep -q kvm
+      register: kvm_support
+      changed_when: false
+      ignore_errors: true
+
+    - name: Set kvm support
+      ansible.builtin.set_fact:
+        qemu_cap_kvm: "{{ kvm_support is defined }}"
+      when: ansible_system == 'Linux'
 
     ### prerequisites #########################################################
 
@@ -137,7 +158,7 @@
       ansible.builtin.copy:
         src: "QEMU_EFI.fd"
         dest: "{{ molecule_driver_directory }}/QEMU_EFI.fd"
-        checksum: "sha256:d28d0f28b31b9982f0bed6123d9e1b9c4b9f49aa57de159808487318056ba89b"
+        checksum: "784ad38513e327287e96d511c9ca0219aa94e672"
         mode: "0644"
       when: "'aarch64' in molecule_instances | map(attribute='image_arch') | list | unique"
 
@@ -260,6 +281,9 @@
         {% if qemu_cap_hvf %}
         -accel hvf
         {% endif %}
+        {% endif %}
+        {% if qemu_cap_kvm and item.image_arch == ansible_machine %}
+        -enable-kvm
         {% endif %}
       args:
         creates: "{{ item.path_pid }}"


### PR DESCRIPTION
# Added
I proposed enabling KVM for Linux Hosts:

1. `create` would first check if the host is running Linux
2. If so, if there is virtualization and KVM support
3. If the conditions are met, `-enable-kvm` option is appended to the qemu command if the target has the same architecture as the host

The performance difference, for the test case of bullseye (**without** ARM, which does not allow KVM), is considerable:

**with kvm**: `make test-os-debian-bullseye  13.38s user 2.03s system 29% cpu 51.826 total`
**without kvm**: `make test-os-debian-bullseye  16.41s user 2.47s system 12% cpu 2:26.58 total`

The bottle neck seems to be cloud-init (Waiting for SSH), and KVM does speed up the process

# Changed
I am getting error with the checksum of the BIOS. By documentation, the copy module only supports sha1 checksum, so I changed that