### PR TITLE
fix(aarch64): use cortex-a72 cpu model

### DIFF
--- a/molecule_qemu/playbooks/create.yml
+++ b/molecule_qemu/playbooks/create.yml
@@ -292,7 +292,7 @@
         -cpu host
         -accel hvf
         {% else %}
-        -cpu cortex-a76
+        -cpu cortex-a72
         {% endif %}
         {% endif %}
         {% if qemu_cap_kvm and item.image_arch == ansible_machine %}


### PR DESCRIPTION
In ubuntu-22.04(which is also the current ubuntu-latest in GitHub Actions), the installed qemu version(6.2.0) does not have the `cortex-a76` available for `aarch64` platform.  
An example failing run is [here](https://github.com/glacion/molecule_template/actions/runs/6225540303/job/16896185133#step:6:225).  
This wasn't caught by this repo's CI as it tests against only the `x86_64` platform.  
